### PR TITLE
Bug/Enhancement - Fixed error message and honored cron messages

### DIFF
--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -29,7 +29,8 @@ processors:
         - '^(%{ECS_SYSLOG_PRI})?%{TIMESTAMP} %{GREEDYDATA:message}'
       pattern_definitions:
         ECS_SYSLOG_PRI: '<%{NONNEGINT:log.syslog.priority:long}>(\d )?'
-        TIMESTAMP: '(?:%{BSD_TIMESTAMP_FORMAT}|%{SYSLOG_TIMESTAMP_FORMAT})'
+        TIMESTAMP: '(?:%{BSD_TIMESTAMP_FORMAT}|%{SYSLOG_TIMESTAMP_FORMAT}|%{CRON_TIMESTAMP_FORMAT})'
+        CRON_TIMESTAMP_FORMAT: '%{SYSLOGTIMESTAMP}.*\/%{NAME:process.name}\[%{POSINT:process.pid:long}\]: \(%{WORD:process.owner}\)'
         BSD_TIMESTAMP_FORMAT: '%{SYSLOGTIMESTAMP:_tmp.timestamp}(%{SPACE}%{BSD_PROCNAME}|%{SPACE}%{OBSERVER}%{SPACE}%{BSD_PROCNAME})(\[%{POSINT:process.pid:long}\])?:'
         BSD_PROCNAME: '(?:\b%{NAME:process.name}|\(%{NAME:process.name}\))'
         NAME: '[[[:alnum:]]_-]+'
@@ -87,7 +88,7 @@ processors:
       name: '{{ IngestPipeline "squid" }}'
       if: ctx.event.provider == 'squid'
   - drop:
-      if: '!["filterlog", "openvpn", "charon", "dhcpd", "dhclient", "dhcp6c", "unbound", "haproxy", "php-fpm", "squid"].contains(ctx.event?.provider)'
+      if: '!["filterlog", "openvpn", "charon", "dhcpd", "dhclient", "dhcp6c", "unbound", "haproxy", "php-fpm", "squid", "cron"].contains(ctx.event?.provider)'
   - append:
       field: event.category
       value: network


### PR DESCRIPTION
## Proposed commit message
The pfsense integration produced `"field [process] not present as part of path [process.name]"` errors for cron messages like the following:
`<78>Nov  7 10:09:00 /usr/sbin/cron[70219]: (root) CMD (/usr/sbin/newsyslog) My solution logs cron messages and removes the error`

My Proposed solution might not be the best but it might be starting of point for someone, or it at least removes the error message 


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
- [x] I have verified that any added dashboard complies with Kibana's [Dashboard good practices](https://docs.elastic.dev/ux-guidelines/data-viz/dashboard-good-practices) 

## Author's Checklist
- [x] Read this text

## How to test this PR locally

Use my example?

## Related issues
- none

## Screenshots

- none
